### PR TITLE
bugfix to allow VPC security group to be overwritten

### DIFF
--- a/lib/tapjoy/autoscaling_bootstrap/autoscaling/config.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/autoscaling/config.rb
@@ -16,7 +16,7 @@ module Tapjoy
           puts "Creating launch config: #{Tapjoy::AutoscalingBootstrap.config_name}"
           begin
             Tapjoy::AutoscalingBootstrap::Base.new.sec_group_exists(
-              aws_env[:security_groups])
+              aws_env[:security_groups]) unless config[:vpc_subnets]
             Tapjoy::AutoscalingBootstrap::AWS::Autoscaling::LaunchConfig.create(
               **config, **aws_env, user_data: user_data)
           rescue Aws::AutoScaling::Errors::ValidationError => err

--- a/lib/tapjoy/autoscaling_bootstrap/version.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/version.rb
@@ -3,7 +3,7 @@ module Tapjoy
     module Version
       MAJOR = 0
       MINOR = 1
-      PATCH = 0
+      PATCH = 1
     end
 
     VERSION = [Version::MAJOR, Version::MINOR, Version::PATCH].join('.')


### PR DESCRIPTION
@Tapjoy/eng-group-ops 

Notes:
* This skips the group existence check for VPC security groups, since sec_group_exists expects a group name, rather than group id.  I'll be opening an issue against the project to allow sec_group_exists to work with VPC security groups.