### PR TITLE
Feature/yaml parsing switch

### DIFF
--- a/bin/tass
+++ b/bin/tass
@@ -23,6 +23,13 @@ def configure_environment(opts)
   [config, aws_env, user_data]
 end
 
+# Are we using a newer yaml schema
+def newer_yaml_version?(config)
+  Tapjoy::AutoscalingBootstrap::Base.new.check_yaml_version(config).split(".").first.to_i >= 2
+end
+
+
+
 SUB_COMMANDS = %w(create update audit scale)
 Trollop::options do
   usage '[SUB_COMMAND] [options]'
@@ -46,27 +53,32 @@ when 'create'
 
   config, aws_env, user_data = configure_environment(opts)
 
-  Tapjoy::AutoscalingBootstrap::Base.new.check_clobber(opts, config)
-  unless confirm_config(aws_env, config, opts)
-    abort('Cannot continue if configuration is not correct.  Please fix.')
-  end
-  Tapjoy::AutoscalingBootstrap::AutoscalingGroup.new.create(opts, config, aws_env, user_data)
+  # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
+  if newer_yaml_version?(config)
+    # TODO: Implement new yaml parsing routine for cloudfront
+    puts "Running new parsing routine with:\nconfig: #{config}\naws_env: #{aws_env}\nuser_data: #{user_data}"
+  else
+    Tapjoy::AutoscalingBootstrap::Base.new.check_clobber(opts, config)
+    unless confirm_config(aws_env, config, opts)
+      abort('Cannot continue if configuration is not correct.  Please fix.')
+    end
+    Tapjoy::AutoscalingBootstrap::AutoscalingGroup.new.create(opts, config, aws_env, user_data)
 
-  if config.key?(:elb)
-    config[:elb].each do |elb|
-      elb.each do |elb_name, elb_config|
-        Tapjoy::AutoscalingBootstrap.elb_name = elb_name
-        elb_hash = {
-          elb_name => config[:default_elb_parameters].merge!(elb[elb_name])
-        }
+    if config.key?(:elb)
+      config[:elb].each do |elb|
+        elb.each do |elb_name, elb_config|
+          Tapjoy::AutoscalingBootstrap.elb_name = elb_name
+          elb_hash = {
+            elb_name => config[:default_elb_parameters].merge!(elb[elb_name])
+          }
 
-        Tapjoy::AutoscalingBootstrap::ELB.new(
-          elb_hash, config[:clobber_elb], config[:zones],
-          config[:security_groups])
+          Tapjoy::AutoscalingBootstrap::ELB.new(
+            elb_hash, config[:clobber_elb], config[:zones],
+            config[:security_groups])
+        end
       end
     end
   end
-
 when 'update'
   opts = Trollop.options do
     # Set help message
@@ -76,9 +88,16 @@ when 'update'
   end
 
   config, aws_env, user_data = configure_environment(opts)
-  confirm_config(aws_env, config, opts)
 
-  Tapjoy::AutoscalingBootstrap::LaunchConfiguration.new(config, aws_env, user_data)
+  # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
+  if newer_yaml_version?(config)
+    # TODO: Implement new yaml parsing routine for cloudfront
+    puts "Running new parsing routine with:\nconfig: #{config}\naws_env: #{aws_env}\nuser_data: #{user_data}"
+  else
+    confirm_config(aws_env, config, opts)
+
+    Tapjoy::AutoscalingBootstrap::LaunchConfiguration.new(config, aws_env, user_data)
+  end
 when 'audit'
   opts = Trollop.options do
     usage 'audit'
@@ -88,8 +107,14 @@ when 'audit'
 
   config, aws_env, user_data = configure_environment(opts)
 
-  config.merge!(aws_env.merge(user_data: Base64.encode64("#{user_data}")))
-  Tapjoy::AutoscalingBootstrap::Audit.new(config)
+  # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
+  if newer_yaml_version?(config)
+    # TODO: Implement new yaml parsing routine for cloudfront
+    puts "Running new parsing routine with:\nconfig: #{config}\naws_env: #{aws_env}\nuser_data: #{user_data}"
+  else
+    config.merge!(aws_env.merge(user_data: Base64.encode64("#{user_data}")))
+    Tapjoy::AutoscalingBootstrap::Audit.new(config)
+  end
 when 'scale'
   opts = Trollop.options do
     usage 'scale [options]'
@@ -99,7 +124,13 @@ when 'scale'
   end
 
   config, aws_env, user_data = configure_environment(opts)
-  Tapjoy::AutoscalingBootstrap::Autoscaling::Group.new.scale(config)
+  # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
+  if newer_yaml_version?(config)
+    # TODO: Implement new yaml parsing routine for cloudfront
+    puts "This command will be covered by #update functionality in the v2 schema"
+  else
+    Tapjoy::AutoscalingBootstrap::Autoscaling::Group.new.scale(config)
+  end
 else
   Trollop.educate
 end

--- a/lib/tapjoy/autoscaling_bootstrap.rb
+++ b/lib/tapjoy/autoscaling_bootstrap.rb
@@ -111,6 +111,12 @@ module Tapjoy
         create_as_group && Tapjoy::AutoscalingBootstrap.group.exists && !clobber_as
       end
 
+      # See what version of the yaml we are running
+      def check_yaml_version(config)
+        # If we don't have one specified assume v1
+        config[:version] ? config[:version] : "1.0.0"
+      end
+
       # Get AWS Environment
       def get_security_groups(config_dir, env, group)
 
@@ -168,6 +174,9 @@ module Tapjoy
         env_hash      = self.load_yaml(File.join(common_path, "#{env}.yaml"))
 
         new_config = defaults_hash.merge!(env_hash).merge(facet_hash)
+
+        # TODO: Only run this part of the configuration and return aws_env and user_data for the older yaml file verison
+
         new_config[:config_dir] = config_dir
         new_config[:instance_ids] = opts[:instance_ids] if opts.key?(:instance_ids)
         aws_env = self.get_security_groups(common_path, env, new_config[:group])
@@ -177,7 +186,6 @@ module Tapjoy
         new_config[:tags] << {Name: new_config[:name]}
         Tapjoy::AutoscalingBootstrap.scaler_name = "#{new_config[:name]}-group"
         Tapjoy::AutoscalingBootstrap.config_name = "#{new_config[:name]}-config"
-        # If there's no ELB, then Not a ELB
         user_data = self.generate_user_data(userdata_dir,
           new_config[:bootstrap_script], new_config)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,10 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.before(:each) do
+    Aws.config[:stub_responses] = true
+  end
+
   config.include BootstrapHelper
 end
 

--- a/spec/tapjoy/autoscaling_bootstrap/alerts/scaling_spec.rb
+++ b/spec/tapjoy/autoscaling_bootstrap/alerts/scaling_spec.rb
@@ -9,10 +9,9 @@ describe Tapjoy::AutoscalingBootstrap::Alerts::Scaling, :vcr do
     })}
 
   it 'creates scaling alerts', :alerts => 'create_alarm' do
-    unless Tapjoy::AutoscalingBootstrap.group.exists
-      asg = Tapjoy::AutoscalingBootstrap::Autoscaling::Group.new
-      asg.create(config: new_config, aws_env: aws_env, user_data: user_data)
-    end
+    scaling_group = double("scaling_group")
+    allow(Tapjoy::AutoscalingBootstrap).to receive(:group).and_return(scaling_group)
+    allow(scaling_group).to receive(:exists).and_return(true)
     expect{Tapjoy::AutoscalingBootstrap::Alerts::Scaling.new(
       config,
     )}.to_not raise_error

--- a/spec/tapjoy/autoscaling_bootstrap/audit_spec.rb
+++ b/spec/tapjoy/autoscaling_bootstrap/audit_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 describe Tapjoy::AutoscalingBootstrap::Audit do
   describe '#new' do
     it 'audits a config file', :audit => 'print' do
+      # Since we stub describe the tag formatting needs to be changed
+      remote_config = new_config.merge(:tags => [{:resource_type=>"auto-scaling-group", :key=>"Name", :value=>"tass-test", :propagate_at_launch=>true}])
+      allow(Tapjoy::AutoscalingBootstrap::AWS::Autoscaling::LaunchConfig).to receive(:describe).and_return(remote_config)
       expect{Tapjoy::AutoscalingBootstrap::Audit.new(new_config)}.to_not raise_error
     end
   end


### PR DESCRIPTION
@Tapjoy/eng-group-ops 

This drives a wedge into the current top level tass commands that allows us to make calls to cloudformation once we've generated valid stack request json/hash (work to be completed in later tasks).

The following tests were succesfull in my local dev environemnt and can be performed using the example yaml files attached: 
```
bundle exec tass scale -f ~/projects/.tass/config/clusters/v1_nonsense_cluster.yaml 
bundle exec tass audit -f ~/projects/.tass/config/clusters/v2_nonsense_cluster.yaml 
bundle exec tass audit -f ~/projects/.tass/config/clusters/v1_nonsense_cluster.yaml 
bundle exec tass create -f ~/projects/.tass/config/clusters/v1_nonsense_cluster.yaml 
bundle exec tass create -f ~/projects/.tass/config/clusters/v2_nonsense_cluster.yaml 
bundle exec tass update -f ~/projects/.tass/config/clusters/v2_nonsense_cluster.yaml 
bundle exec tass update -f ~/projects/.tass/config/clusters/v1_nonsense_cluster.yaml 
```