### PR TITLE
Feature/yaml parsing switch

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Tapjoy, Inc.
+Copyright (c) 2015-2016 Tapjoy, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,4 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/bin/tass
+++ b/bin/tass
@@ -39,7 +39,7 @@ SUB_COMMANDS = %w(create update audit scale)
 Trollop::options do
   usage '[SUB_COMMAND] [options]'
   synopsis "\nConfigures autoscaling groups.\nAvailable subcommands are: #{SUB_COMMANDS}"
-  version "#{File.basename($PROGRAM_NAME)} #{Tapjoy::AutoscalingBootstrap::VERSION} \u00A9 2015 Tapjoy, Inc."
+  version "#{File.basename($PROGRAM_NAME)} #{Tapjoy::AutoscalingBootstrap::VERSION} \u00A9 2015-2016 Tapjoy, Inc."
   stop_on SUB_COMMANDS
 end
 
@@ -57,10 +57,17 @@ when 'create'
   end
 
   config = initialize_environment(opts)
+  sfr_config = {}  # @TODO: remove this when SFR config becomes sane
 
   # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
   if newer_yaml_version?(config)
     # Determine if we are making a cloudformation request
+    if config[:stack][:spot_fleet]
+      sfr_config.merge!(config[:stack][:spot_fleet][:config_data])
+      config[:stack].delete(:spot_fleet)
+      Tapjoy::AutoscalingBootstrap::EC2.request_spot_instances(sfr_config,
+        config[:userdata_dir])
+    end
     if config[:stack]
       # And if we are format the config into readable JSON for the request
       request_parmeter_hash = Tapjoy::AutoscalingBootstrap::Cloudformation.prepare_options_hash(config)

--- a/bin/tass
+++ b/bin/tass
@@ -16,10 +16,15 @@ def confirm_config(aws_env, misc_config, opts)
     config: misc_config)
 end
 
-def configure_environment(opts)
-  warn('NOTE: --env has been deprecated.  Please specify environment in yaml configs.') if opts.key?(:env)
-  config, aws_env, user_data = Tapjoy::AutoscalingBootstrap::Base.new.configure_environment(opts)
+def initialize_environment(opts)
+  config = Tapjoy::AutoscalingBootstrap::Base.new.initialize_environment(opts)
   Aws.config[:region] = config[:aws_region]
+  config
+end
+
+def legacy_configure_environment(opts)
+  warn('NOTE: --env has been deprecated.  Please specify environment in yaml configs.') if opts.key?(:env)
+  config, aws_env, user_data = Tapjoy::AutoscalingBootstrap::Base.new.legacy_configure_environment(opts)
   [config, aws_env, user_data]
 end
 
@@ -51,13 +56,26 @@ when 'create'
     common_args
   end
 
-  config, aws_env, user_data = configure_environment(opts)
+  config = initialize_environment(opts)
 
   # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
   if newer_yaml_version?(config)
-    # TODO: Implement new yaml parsing routine for cloudfront
-    puts "Running new parsing routine with:\nconfig: #{config}\naws_env: #{aws_env}\nuser_data: #{user_data}"
+    # Determine if we are making a cloudformation request
+    if config[:stack]
+      # And if we are format the config into readable JSON for the request
+      request_parmeter_hash = Tapjoy::AutoscalingBootstrap::Cloudformation.prepare_options_hash(config)
+      puts "This is the current request paramter hash: #{request_parmeter_hash}"
+      puts "\nAnd it's parsable as JSON:\n"
+      puts JSON.parse request_parmeter_hash[:template_body]
+
+    else
+    # TODO potentially tie into the old methods if we aren't making a cloudformation request
+    puts "Non cloudformation-based requests will be implemented at a later date."
+    end
   else
+    # Run the legacy code
+    config, aws_env, user_data = legacy_configure_environment(config)
+    puts "finished the config"
     Tapjoy::AutoscalingBootstrap::Base.new.check_clobber(opts, config)
     unless confirm_config(aws_env, config, opts)
       abort('Cannot continue if configuration is not correct.  Please fix.')
@@ -87,13 +105,19 @@ when 'update'
     common_args
   end
 
-  config, aws_env, user_data = configure_environment(opts)
+  config = initialize_environment(opts)
 
   # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
   if newer_yaml_version?(config)
-    # TODO: Implement new yaml parsing routine for cloudfront
-    puts "Running new parsing routine with:\nconfig: #{config}\naws_env: #{aws_env}\nuser_data: #{user_data}"
+    # Determine if we are making a cloudformation request
+    if config[:stack]
+      # And if we are format the config into readable JSON for the request
+    else
+    # TODO potentially tie into the old methods if we aren't making a cloudformation request
+    puts "Non cloudformation-based requests will be implemented at a later date."
+    end
   else
+    config, aws_env, user_data = legacy_configure_environment(config)
     confirm_config(aws_env, config, opts)
 
     Tapjoy::AutoscalingBootstrap::LaunchConfiguration.new(config, aws_env, user_data)
@@ -105,13 +129,15 @@ when 'audit'
     common_args
   end
 
-  config, aws_env, user_data = configure_environment(opts)
+  config = initialize_environment(opts)
+
 
   # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
   if newer_yaml_version?(config)
     # TODO: Implement new yaml parsing routine for cloudfront
-    puts "Running new parsing routine with:\nconfig: #{config}\naws_env: #{aws_env}\nuser_data: #{user_data}"
+    puts "Running new parsing routine with:\nconfig: #{config}"
   else
+    config, aws_env, user_data = legacy_configure_environment(config)
     config.merge!(aws_env.merge(user_data: Base64.encode64("#{user_data}")))
     Tapjoy::AutoscalingBootstrap::Audit.new(config)
   end
@@ -123,12 +149,14 @@ when 'scale'
     opt :instance_ids, 'Instance IDs to scale down', type: :strings
   end
 
-  config, aws_env, user_data = configure_environment(opts)
+  config = initialize_environment(opts)
+
   # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
   if newer_yaml_version?(config)
     # TODO: Implement new yaml parsing routine for cloudfront
     puts "This command will be covered by #update functionality in the v2 schema"
   else
+    config, aws_env, user_data = configure_environment(config)
     Tapjoy::AutoscalingBootstrap::Autoscaling::Group.new.scale(config)
   end
 else

--- a/bin/tass
+++ b/bin/tass
@@ -11,8 +11,8 @@ end
 def confirm_config(aws_env, misc_config, opts)
   use_vpc = true if misc_config[:vpc_subnets]
   has_elb = true if misc_config.key?(:elb)
-  Tapjoy::AutoscalingBootstrap::Base.new.confirm_config(**aws_env,
-    **misc_config, **opts, use_vpc: use_vpc, has_elb: has_elb,
+  Tapjoy::AutoscalingBootstrap::Base.new.confirm_config(
+    **aws_env, **misc_config, **opts, use_vpc: use_vpc, has_elb: has_elb,
     config: misc_config)
 end
 
@@ -30,13 +30,11 @@ end
 
 # Are we using a newer yaml schema
 def newer_yaml_version?(config)
-  Tapjoy::AutoscalingBootstrap::Base.new.check_yaml_version(config).split(".").first.to_i >= 2
+  Tapjoy::AutoscalingBootstrap::Base.new.check_yaml_version(config).split('.').first.to_i >= 2
 end
 
-
-
 SUB_COMMANDS = %w(create update audit scale)
-Trollop::options do
+Trollop.options do
   usage '[SUB_COMMAND] [options]'
   synopsis "\nConfigures autoscaling groups.\nAvailable subcommands are: #{SUB_COMMANDS}"
   version "#{File.basename($PROGRAM_NAME)} #{Tapjoy::AutoscalingBootstrap::VERSION} \u00A9 2015-2016 Tapjoy, Inc."
@@ -57,16 +55,22 @@ when 'create'
   end
 
   config = initialize_environment(opts)
-  sfr_config = {}  # @TODO: remove this when SFR config becomes sane
+  sfr_config = {} # @TODO: remove this when SFR config becomes sane
 
-  # check the verison of the yaml we are reading, and do the new hotness if we are running v2 or higher
+  # check the verison of the yaml we are reading, and do the new hotness
+  # if we are running v2 or higher
   if newer_yaml_version?(config)
     # Determine if we are making a cloudformation request
     if config[:stack][:spot_fleet]
       sfr_config.merge!(config[:stack][:spot_fleet][:config_data])
       config[:stack].delete(:spot_fleet)
-      Tapjoy::AutoscalingBootstrap::EC2.request_spot_instances(sfr_config,
-        config[:userdata_dir])
+      Tapjoy::AutoscalingBootstrap::EC2::SpotFleets.request(
+        sfr_config, config[:userdata_dir])
+      print 'Spot Request Granted.  '
+      puts "Id: #{Tapjoy::AutoscalingBootstrap::EC2::SpotFleets.request_id}"
+      Tapjoy::TASS::AWS::Cloudwatch.create_spot_fleet_alarm(config)
+      Tapjoy::TASS.plan
+      Tapjoy::TASS.apply
     end
     if config[:stack]
       # And if we are format the config into readable JSON for the request
@@ -76,18 +80,20 @@ when 'create'
       puts JSON.parse request_parmeter_hash[:template_body]
 
     else
-    # TODO potentially tie into the old methods if we aren't making a cloudformation request
-    puts "Non cloudformation-based requests will be implemented at a later date."
+    # @TODO: potentially tie into the old methods if we aren't
+    # making a cloudformation request
+    puts 'Non cloudformation-based requests will be implemented at a later date.'
     end
   else
     # Run the legacy code
     config, aws_env, user_data = legacy_configure_environment(config)
-    puts "finished the config"
+    puts 'finished the config'
     Tapjoy::AutoscalingBootstrap::Base.new.check_clobber(opts, config)
     unless confirm_config(aws_env, config, opts)
       abort('Cannot continue if configuration is not correct.  Please fix.')
     end
-    Tapjoy::AutoscalingBootstrap::AutoscalingGroup.new.create(opts, config, aws_env, user_data)
+    Tapjoy::AutoscalingBootstrap::AutoscalingGroup.new.create(
+      opts, config, aws_env, user_data)
 
     if config.key?(:elb)
       config[:elb].each do |elb|

--- a/lib/tapjoy/autoscaling_bootstrap.rb
+++ b/lib/tapjoy/autoscaling_bootstrap.rb
@@ -32,6 +32,8 @@ require_relative 'autoscaling_bootstrap/launch_configuration'
 require_relative 'autoscaling_bootstrap/version'
 require_relative 'autoscaling_bootstrap/audit'
 require_relative 'autoscaling_bootstrap/ec2'
+require_relative 'autoscaling_bootstrap/EC2/spot_fleets'
+require_relative 'tass'
 
 module Tapjoy
   # Module for Autoscaling Bootstrap
@@ -39,10 +41,12 @@ module Tapjoy
     # This class is meant for class and instances variables used throughout
     # the application.
     class << self
-      attr_accessor :scaler_name, :config_name, :create_elb
+      attr_accessor :scaler_name, :config_name, :create_elb,
+                    :template_dir, :config_dir, :terraform_path
       attr_reader :elb_name
 
-      # If you're using AutoscalingBootstrap to create a new ELB, that name goes here
+      # If you're using AutoscalingBootstrap to create a new ELB,
+      # that name goes here
       def elb_name=(str)
         @elb_name = str
       end
@@ -162,9 +166,11 @@ module Tapjoy
       # Combine default values, values from yaml, and cli options
       def initialize_environment(opts)
         filename = opts[:filename]
-        facet_file    = filename
-        config_dir    = File.expand_path('../..', facet_file)
+        facet_file = filename
+        Tapjoy::AutoscalingBootstrap.config_dir = File.expand_path('../..', facet_file)
+        config_dir = Tapjoy::AutoscalingBootstrap.config_dir
         userdata_dir  = "#{File.expand_path('../../..', facet_file)}/userdata"
+        Tapjoy::AutoscalingBootstrap.template_dir = "#{File.expand_path('../../..', facet_file)}/templates"
 
         common_path   = File.join(config_dir, 'common')
         defaults_hash = self.load_yaml(File.join(common_path, 'defaults.yaml'))
@@ -174,9 +180,9 @@ module Tapjoy
         env_hash      = self.load_yaml(File.join(common_path, "#{env}.yaml"))
         config = defaults_hash.merge!(env_hash).merge!(facet_hash).merge(opts)
         config[:userdata_dir] = userdata_dir
+        Tapjoy::AutoscalingBootstrap.terraform_path = tf_path(config)
         config
       end
-
 
       # Additional environment configuration used by legacy tooling
       def legacy_configure_environment(opts)
@@ -229,6 +235,14 @@ module Tapjoy
             Tapjoy::AutoscalingBootstrap::AWS::EC2.create_security_group(group)
           end
         end
+      end
+
+      def tf_path(config)
+        @tf_path = File.join(
+          Tapjoy::AutoscalingBootstrap.config_dir, 'clusters',
+          config[:stack][:name])
+        Dir.mkdir @tf_path unless Dir.exist?(@tf_path)
+        @tf_path
       end
     end
   end

--- a/lib/tapjoy/autoscaling_bootstrap/AWS/cloudformation.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/AWS/cloudformation.rb
@@ -1,0 +1,28 @@
+module Tapjoy
+  module AutoscalingBootstrap
+    module AWS
+      module Cloudformation
+        class << self
+          def client
+            @client ||= Aws::CloudFormation::Client.new
+          end
+
+          def create_stack(**argument_hash)
+            ## TODO: get this working
+            # self.client.create_stack(**argument_hash)
+          end
+
+          def update_stack(**argument_hash)
+            ## TODO: get this working
+            # self.client.update_stack(**argument_hash)
+          end
+
+          def validate_template(**argument_hash)
+            ## TODO: get this working
+            # self.client.validate_template(**argument_hash)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapjoy/autoscaling_bootstrap/AWS/ec2.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/AWS/ec2.rb
@@ -1,7 +1,7 @@
 module Tapjoy
   module AutoscalingBootstrap
     module AWS
-    # This class contains AWS methods for EC2
+      # This class contains AWS methods for EC2
       module EC2
         class << self
           def client
@@ -33,6 +33,27 @@ module Tapjoy
 
           def terminate_instances(instance_ids)
             client.terminate_instances(instance_ids: instance_ids)
+          end
+
+          def request_spot_instances(spot_price:, target_capacity:,
+            iam_fleet_role:, excess_capacity_termination_policy:,
+            allocation_strategy:, userdata_dir:, **config)
+            config[:launch_specifications].each do |spec|
+              user_data = Tapjoy::AutoscalingBootstrap::Base.new.generate_user_data(
+                userdata_dir, spec[:bootstrap_script], config)
+              spec[:user_data] = Base64.encode64("#{user_data}")
+              spec.delete(:bootstrap_script)
+            end
+
+            client.request_spot_fleet(
+              spot_fleet_request_config: { # required
+                spot_price: spot_price, # required
+                target_capacity: target_capacity, # required
+                iam_fleet_role: iam_fleet_role, # required
+                launch_specifications: config[:launch_specifications],
+                excess_capacity_termination_policy: excess_capacity_termination_policy,
+                allocation_strategy: allocation_strategy
+              })
           end
         end
       end

--- a/lib/tapjoy/autoscaling_bootstrap/AWS/ec2.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/AWS/ec2.rb
@@ -35,7 +35,7 @@ module Tapjoy
             client.terminate_instances(instance_ids: instance_ids)
           end
 
-          def request_spot_instances(spot_price:, target_capacity:,
+          def request_spot_fleet(spot_price:, target_capacity:,
             iam_fleet_role:, excess_capacity_termination_policy:,
             allocation_strategy:, userdata_dir:, **config)
             config[:launch_specifications].each do |spec|

--- a/lib/tapjoy/autoscaling_bootstrap/EC2/spot_fleets.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/EC2/spot_fleets.rb
@@ -1,0 +1,17 @@
+module Tapjoy
+  module AutoscalingBootstrap
+    module EC2
+      # Code specific to Launch Configs
+      module SpotFleets
+        class << self
+          attr_accessor :request_id
+
+          def request(config, userdata_dir)
+            self.request_id = Tapjoy::AutoscalingBootstrap::AWS::EC2.request_spot_fleet(
+              userdata_dir: userdata_dir, **config).spot_fleet_request_id
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/tapjoy/autoscaling_bootstrap/cloudformation.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/cloudformation.rb
@@ -1,0 +1,63 @@
+require 'awrence'
+
+module Tapjoy
+  module AutoscalingBootstrap
+    # This module formats configuration data for use with cloudformation requests
+    module Cloudformation
+      class << self
+        # Prep the options for inclusion in a cloudformation request
+        def prepare_options_hash(config)
+          puts "Preparing options for cloudwatch request"
+
+          # Initialize a cloudwatch hash so we can create a template body for the cf request
+          cf_hash = {
+            # TODO: turn AWS template version into cli param with sensible default
+            "AWSTemplateFormatVersion" => "2010-09-09",
+            "Resources" => {}
+          }
+
+          # Now process the recognized resources so we can format them properly
+          config[:stack].keys.each do |key|
+            case key
+            when :spot_fleet
+              cf_hash["Resources"][config[:stack][key][:name]] = self.process_spot_fleet_config(config)
+              # TODO: Implement other resource types (asg, launch config, etc.)
+            else
+              puts "Unrecognized resource #{key} specified in stack. Skipping #{key}."
+            end
+          end
+
+          request_params = {
+            #TODO: add other required params for request
+            :template_body => cf_hash.to_json
+          }
+        end
+
+        def process_spot_fleet_config(config)
+          # Take the spot fleet config data and format it into a usuable item in the Resources hash
+          spot_fleet_hash = {
+            "Type" => "AWS::EC2::SpotFleet",
+            "Properties" => {  "SpotFleetRequestConfigData" => ""}
+          }
+
+          # To keep the yaml config size manageable we parse out the specified bootstrap script
+          # into an array here and apply it to each launch config
+          filename = config[:filename]
+          facet_file    = filename
+          userdata_dir  = "#{File.expand_path('../../..', facet_file)}/userdata"
+          # CamelCase the spot fleet hash keys so they'll be recognized by AWS. Thank you awrence
+          spot_fleet_config = config[:stack][:spot_fleet][:config_data].to_camel_keys
+          # Use the newlines to split the config into an array, then add the newline characters back
+          # so we can reconstitute the bootstrap properly later
+          boostrap_script_array = Tapjoy::AutoscalingBootstrap::Base.new.generate_user_data(userdata_dir,
+            config[:stack][:spot_fleet][:bootstrap_script], config).split("\n").map{|line| line << "\n"}
+          # Add the bootstrap as all of the launch config's UserData setting.
+          # Fn calls are interpreted by cloudformation/spotfleet as a way to reconstitute the script
+          spot_fleet_config[:LaunchSpecifications].each{|ls| ls["UserData"] = {"Fn::Base64" => {"Fn::Join" => ["", boostrap_script_array]}}}
+          spot_fleet_config
+        end
+
+      end
+    end
+  end
+end

--- a/lib/tapjoy/autoscaling_bootstrap/ec2.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/ec2.rb
@@ -15,12 +15,6 @@ module Tapjoy
           Tapjoy::AutoscalingBootstrap::AWS::EC2.toggle_termination_protection(instance_id, 'false')
         end
 
-        def request_spot_instances(config, userdata_dir)
-          Tapjoy::AutoscalingBootstrap::AWS::EC2.request_spot_instances(
-            userdata_dir: userdata_dir, **config)
-          exit 1
-        end
-
         private
         def find_static_instances(config)
           response = Tapjoy::AutoscalingBootstrap::AWS::EC2.describe_instances_by_tag(config)

--- a/lib/tapjoy/autoscaling_bootstrap/ec2.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/ec2.rb
@@ -15,6 +15,12 @@ module Tapjoy
           Tapjoy::AutoscalingBootstrap::AWS::EC2.toggle_termination_protection(instance_id, 'false')
         end
 
+        def request_spot_instances(config, userdata_dir)
+          Tapjoy::AutoscalingBootstrap::AWS::EC2.request_spot_instances(
+            userdata_dir: userdata_dir, **config)
+          exit 1
+        end
+
         private
         def find_static_instances(config)
           response = Tapjoy::AutoscalingBootstrap::AWS::EC2.describe_instances_by_tag(config)

--- a/lib/tapjoy/autoscaling_bootstrap/version.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/version.rb
@@ -3,7 +3,7 @@ module Tapjoy
     module Version
       MAJOR = 1
       MINOR = 0
-      PATCH = 1
+      PATCH = 2
     end
 
     VERSION = [Version::MAJOR, Version::MINOR, Version::PATCH].join('.')

--- a/lib/tapjoy/tass.rb
+++ b/lib/tapjoy/tass.rb
@@ -1,0 +1,30 @@
+require_relative 'tass/aws'
+require_relative 'tass/aws/cloudwatch'
+module Tapjoy
+  # module to hold new-style tass code
+  module TASS
+    class << self
+      def plan
+        outfile = File.join(Tapjoy::AutoscalingBootstrap.terraform_path, 'plan')
+        has_plan = system("terraform plan -out=#{outfile} #{Tapjoy::AutoscalingBootstrap.terraform_path}", out: File::NULL)
+        if has_plan
+          puts `terraform show #{outfile}`
+        else
+          abort("Failed to write plan to #{outfile}")
+        end
+
+        abort('Exiting...') unless agree('Is this information correct? [y/n]')
+      end
+
+      def apply
+        statefile = File.join(Tapjoy::AutoscalingBootstrap.terraform_path, 'terraform.state')
+        planfile = File.join(Tapjoy::AutoscalingBootstrap.terraform_path, 'plan')
+        begin
+          puts `terraform apply -state=#{statefile} #{Tapjoy::AutoscalingBootstrap.terraform_path}`
+        rescue
+          abort("Failed to apply #{planfile} to #{statefile}")
+        end
+      end
+    end
+  end
+end

--- a/lib/tapjoy/tass/aws.rb
+++ b/lib/tapjoy/tass/aws.rb
@@ -1,0 +1,5 @@
+module TASS
+  # module for AWS-specific tass code
+  module AWS
+  end
+end

--- a/lib/tapjoy/tass/aws/cloudwatch.rb
+++ b/lib/tapjoy/tass/aws/cloudwatch.rb
@@ -1,0 +1,32 @@
+module Tapjoy
+  module TASS
+    module AWS
+      # This module configures cloudwatch alarms
+      module Cloudwatch
+        class << self
+          # Create autoscaling alarms
+          def create_spot_fleet_alarm(config)
+            # puts "Creating: #{scale_alert[:alarm]}"
+            tf_file = open(
+              File.join(Tapjoy::AutoscalingBootstrap.terraform_path,
+                        'cloudwatch.tf'), 'w+')
+            tf_file.write(
+              ERB.new(File.new(template_file).read, nil, '-').result(binding)
+            )
+            tf_file.close
+          end
+
+          private
+
+          def template_file
+            @template_file ||= File.join(
+              Tapjoy::AutoscalingBootstrap.template_dir, 'cloudwatch.tf.erb')
+          end
+
+          # @TODO: Move this to base class
+
+        end
+      end
+    end
+  end
+end

--- a/spec/support/bootstrap_helper.rb
+++ b/spec/support/bootstrap_helper.rb
@@ -10,10 +10,10 @@ module BootstrapHelper
     let(:elb_name)                { 'test-elb' }
     let(:cluster_filename)        { 'spec/fixtures/config/clusters/test_cluster.yaml' }
     let(:opts)                    {
-      {env: 'qa', filename: cluster_filename}
+      { environment: 'qa', filename: cluster_filename }
     }
     let(:facet_hash)              { util.load_yaml(cluster_filename) }
-    let(:environment)             { util.configure_environment(opts) }
+    let(:environment)             { util.legacy_configure_environment(opts) }
     let(:new_config)              { environment[0] }
     let(:aws_env)                 { environment[1] }
     let(:user_data)               { environment[2] }
@@ -26,10 +26,10 @@ module BootstrapHelper
       @elb_name = 'test-elb'
       @cluster_filename = './spec/fixtures/config/clusters/test_cluster.yaml'
       @opts = {
-        env:        'qa',
+        environment:        'qa',
         filename:   @cluster_filename
       }
-      @environment = @util.configure_environment(@opts)
+      @environment = @util.legacy_configure_environment(@opts)
       @elb_hash = {
         @elb_name => @environment.first[:default_elb_parameters].merge!(elb_port: 80)
       }

--- a/tass.gemspec
+++ b/tass.gemspec
@@ -16,9 +16,11 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('highline', '~> 1.0')
   s.add_runtime_dependency('aws-sdk', '~> 2.0')
   s.add_runtime_dependency('hashdiff', '~> 0.2')
+  s.add_runtime_dependency('awrence', '~> 0.1.0')
   s.add_development_dependency('rspec', '~> 3.2')
   s.add_development_dependency('activesupport', '~> 4.2')
   s.add_development_dependency('webmock', '~> 1.20')
   s.add_development_dependency('vcr', '~> 2.9')
   s.add_development_dependency('rspec_junit_formatter', '0.2.2')
+  s.add_development_dependency('pry', '0.10.3')
 end


### PR DESCRIPTION
@Tapjoy/eng-group-ops the objective of this task was to be able to parse out spot fleet information from a yaml file in the agreed upon v2 yaml data format. As it currently stands now:

- We have an alpha version of a yaml file that will potentially launch a jobs-default spot fleet via cloudformation request(can be verified once cloudformation calls are fleshed out)
- We have an alpha version of bootstrap script that can launch a jobs-default spot fleet.
- The newly crafted Tapjoy::AutoscalingBootstrap::Cloudformation module can prepare and format spot fleet config from a yaml file to be included as a resource as part of data included in the `template_body` argument to AWS cloudformation api calls. See http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudFormation/Client.html#create_stack-instance_method for reference

Obviously this is extremely rough around the edges. Aside from the TODOs mentioned in code, some other follow on tasks include:

- Cleaning up the config hash keyspace. Because we're aiming for backward compatibility there is a quite a few keys not being used. 

-For the sake of expediency and to keep the scope of the work here as focused as possible I hard coded some vars in the bootstrap (recipes, tags) that we should probably include as attributes of the spot fleet resource definition. We should have a discussion about this when we are all in office. 

I've tested this locally and reviewed the results visually but won't be able to perform and end to end test until the rest of the arguments needed for cloudformation api calls are fleshed out. I threw in a placeholder class for how I thought we might tie into the cloudformation api without completely trying to upend the existing layout/style.

Supporting spot fleet yaml and bootstrap:  https://github.com/Tapjoy/.tass/pull/202