### PR TITLE
[OPER-2313] Parse global and per launch config tags and recipes in sp…

### DIFF
--- a/lib/tapjoy/autoscaling_bootstrap/AWS/ec2.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/AWS/ec2.rb
@@ -39,10 +39,19 @@ module Tapjoy
             iam_fleet_role:, excess_capacity_termination_policy:,
             allocation_strategy:, userdata_dir:, **config)
             config[:launch_specifications].each do |spec|
+              # Make a fresh copy of the passed config
+              # so we can set the recipes and tags to be used in the user_data
+              user_data_config = {}
+              user_data_config.merge!(config)
+              set_recipes_and_tags(user_data_config, spec)
               user_data = Tapjoy::AutoscalingBootstrap::Base.new.generate_user_data(
-                userdata_dir, spec[:bootstrap_script], config)
+                userdata_dir, spec[:bootstrap_script], user_data_config)
               spec[:user_data] = Base64.encode64("#{user_data}")
+              # Remove the bootstrap related config from the launch specification
+              # or the EC2 Spot Fleet call will fail
               spec.delete(:bootstrap_script)
+              spec.delete(:recipes)
+              spec.delete(:tags)
             end
 
             client.request_spot_fleet(
@@ -55,6 +64,22 @@ module Tapjoy
                 allocation_strategy: allocation_strategy
               })
           end
+
+          def set_recipes_and_tags(user_data_config, launch_spec_config)
+            # Look for specified recipes and tags in the spot fleet launch specification
+            # and set the appropriate values
+            keys = [:recipes, :tags]
+            keys.each do |key|
+              if launch_spec_config[key]
+                user_data_config[key] = launch_spec_config[key]
+              else
+                msg = "No #{key.to_s} have been specified for the " +
+                  "#{launch_spec_config[:instance_type]} launch specification"
+                abort(msg)
+              end
+            end
+          end
+
         end
       end
     end


### PR DESCRIPTION
…ot fleet user data scripts.

@Tapjoy/eng-group-ops this allows to set global and per launch instance recipe and tags in each spot fleet config contained in a yaml for use in the updated spot fleet bootstrap script in https://github.com/Tapjoy/.tass/pull/212. 

Tested adjusted methods in isolation successfully. User data was parsed from bootstrap erb without parsing errors but stopped short of allowing it to run though a full ec2 spot fleet request. 