### PR TITLE
use UTC in datestamp #34

### DIFF
--- a/lib/tapjoy/autoscaling_bootstrap/launch_configuration.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/launch_configuration.rb
@@ -35,7 +35,7 @@ module Tapjoy
       end
 
       def date_stamp
-        Time.now.strftime('%Y%m%d-%H%M%S')
+        Time.now.utc.strftime('%Y%m%d-%H%M%S')
       end
     end
   end


### PR DESCRIPTION
@jlogsdon 
/cc @Tapjoy/eng-group-ops 

Notes:
* References #34 
* This fix is only implemented in v2.0.0 (currently in beta), as it's not an urgent fix.