### PR TITLE
Add spot pricing option to launch config

### DIFF
--- a/docs/CONFIG_OPTIONS.md
+++ b/docs/CONFIG_OPTIONS.md
@@ -44,6 +44,7 @@
 :vpc_subnets:                    # (String) Comma-separated list of VPC subnets to assign to autoscaler (valid for VPC instances only)
 :classic_link_vpc_id:            # (String) VPC id to use for ClassicLink (valid for EC2-Classic instances only)
 :classic_link_sg_ids:            # (String Array) VPC subnets to use for ClassicLink (valid for EC2-Classic instances only)
+:spot_price:                     # (String) The maximum hourly price to be paid for any Spot Instance launched to fulfill the request. (valid for spot instances only)
 :termination_policies:           # (String Array) List of termination policies to apply to autoscaler (reference AWS documentation for further info)
 
 :scaling_type:                   # (String) Type of scaling group to create.  At this time, the value should either be 'dynamic' or 'static'.

--- a/lib/tapjoy/autoscaling_bootstrap/AWS/Autoscaling/launch_config.rb
+++ b/lib/tapjoy/autoscaling_bootstrap/AWS/Autoscaling/launch_config.rb
@@ -16,7 +16,7 @@ module Tapjoy
 
             def create(image_id:, instance_type:, security_groups:, user_data:,
               keypair:, iam_instance_profile:, classic_link_vpc_id: nil,
-              classic_link_sg_ids: nil, **unused_values)
+              classic_link_sg_ids: nil, spot_price: nil, **unused_values)
 
               self.client.create_launch_configuration(
                 launch_configuration_name: Tapjoy::AutoscalingBootstrap.config_name,
@@ -28,6 +28,7 @@ module Tapjoy
                 key_name: keypair,
                 classic_link_vpc_id: classic_link_vpc_id,
                 classic_link_vpc_security_groups: classic_link_sg_ids,
+                spot_price: spot_price,
               )
             end
 


### PR DESCRIPTION
@atayarani Tested by doing the following:

* Added `:spot_price: 0.1` - result, no spot price (needed to be a string), all other settings look good.
* No spot price value at all - no spot price, all other settings look good
* Added `:spot_price: '0.1'` - creates launch config with spot price of 0.1